### PR TITLE
multi-datasets, at least when homogeneous

### DIFF
--- a/lerobot/common/utils/wandb_utils.py
+++ b/lerobot/common/utils/wandb_utils.py
@@ -30,9 +30,18 @@ def cfg_to_group(cfg: TrainPipelineConfig, return_list: bool = False) -> list[st
     """Return a group name for logging. Optionally returns group name as list."""
     lst = [
         f"policy:{cfg.policy.type}",
-        f"dataset:{cfg.dataset.repo_id}",
         f"seed:{cfg.seed}",
     ]
+
+    # Handle repo_id as either a string or a list
+    if isinstance(cfg.dataset.repo_id, list):
+        # If it's a list, don't add dataset tag at all
+        # This is a limitation when the repo names are too long lol,
+        # exceeds wandb's max tag length of 64 chars.
+        pass
+    else:
+        lst.append(f"dataset:{cfg.dataset.repo_id}")
+
     if cfg.env is not None:
         lst.append(f"env:{cfg.env.type}")
     return lst if return_list else "-".join(lst)

--- a/lerobot/configs/default.py
+++ b/lerobot/configs/default.py
@@ -29,10 +29,10 @@ class DatasetConfig:
     # keys common between the datasets are kept. Each dataset gets and additional transform that inserts the
     # "dataset_index" into the returned item. The index mapping is made according to the order in which the
     # datasets are provided.
-    repo_id: str
+    repo_id: list[str] | str  # Importantly, list hast to be first for parsing to work *eyeroll*.
     # Root directory where the dataset will be stored (e.g. 'dataset/path').
     root: str | None = None
-    episodes: list[int] | None = None
+    episodes: list[int] | dict[str, list[int]] | None = None
     image_transforms: ImageTransformsConfig = field(default_factory=ImageTransformsConfig)
     revision: str | None = None
     use_imagenet_stats: bool = True

--- a/lerobot/configs/train.py
+++ b/lerobot/configs/train.py
@@ -108,8 +108,8 @@ class TrainPipelineConfig(HubMixin):
             train_dir = f"{now:%Y-%m-%d}/{now:%H-%M-%S}_{self.job_name}"
             self.output_dir = Path("outputs/train") / train_dir
 
-        if isinstance(self.dataset.repo_id, list):
-            raise NotImplementedError("LeRobotMultiDataset is not currently implemented.")
+        # Multi-dataset support is now available via MultiHomogeneousLeRobotDataset
+        # No validation needed here as factory.py handles the logic
 
         if not self.use_policy_training_preset and (self.optimizer is None or self.scheduler is None):
             raise ValueError("Optimizer and Scheduler must be set when the policy presets are not used.")


### PR DESCRIPTION
Create a new multi homogeneous dataset, where it essentially concats the datasets you pass for repo_id instead.

A bit hacky but it should do.

Example command:

```
python lerobot/scripts/train.py --dataset.repo_id='["sriramsk/plate_in_bin_20250821_subsampled_noWrist", "sriramsk/plate_in_bin_20250821_subsampled_noWrist"]' --policy.type=diffusion --output_dir=outputs/train/concat_debug_tracked2 --job_name=diffPo_plate_in_bin_0821 --policy.device=cuda --wandb.enable=true --policy.use_separate_rgb_encoder_per_camera=true --policy.use_text_embedding=true

```

Wandb run: https://wandb.ai/r-pad/lerobot/runs/ok3iuj1o