### PR TITLE
added ability to filter image obs

### DIFF
--- a/lerobot/common/policies/factory.py
+++ b/lerobot/common/policies/factory.py
@@ -136,9 +136,25 @@ def make_policy(
             )
         features = env_to_policy_features(env_cfg)
 
+    # Filter features by action type for output
     cfg.output_features = {key: ft for key, ft in features.items() if ft.type is FeatureType.ACTION}
-    cfg.input_features = {key: ft for key, ft in features.items() if key not in cfg.output_features}
-    
+
+    # Get all non-action features
+    non_action_features = {key: ft for key, ft in features.items() if key not in cfg.output_features}
+
+    # Separate visual and non-visual features
+    visual_features = {key: ft for key, ft in non_action_features.items() if ft.type is FeatureType.VISUAL}
+    non_visual_features = {key: ft for key, ft in non_action_features.items() if ft.type is not FeatureType.VISUAL}
+
+    # Filter visual features by input_image_feature_keys if specified
+    if cfg.input_image_feature_keys is not None:
+        filtered_visual_features = {key: ft for key, ft in visual_features.items() if key in cfg.input_image_feature_keys}
+    else:
+        filtered_visual_features = visual_features
+
+    # Combine filtered visual features with all non-visual features
+    cfg.input_features = {**filtered_visual_features, **non_visual_features}
+
     kwargs["config"] = cfg
 
     if cfg.pretrained_path:

--- a/lerobot/configs/policies.py
+++ b/lerobot/configs/policies.py
@@ -47,6 +47,9 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
             normalization mode to apply.
         output_normalization_modes: Similar dictionary as `input_normalization_modes`, but to unnormalize to
             the original scale.
+        input_image_feature_keys: Optional list of visual feature keys to include in input_features. If None, all
+            visual features are included. If provided, only visual features in this list are included in input_features.
+            Non-visual features (state, proprioceptive) are always included.
     """
 
     n_obs_steps: int = 1
@@ -54,6 +57,7 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
 
     input_features: dict[str, PolicyFeature] = field(default_factory=dict)
     output_features: dict[str, PolicyFeature] = field(default_factory=dict)
+    input_image_feature_keys: list[str] | None = None
 
     device: str | None = None  # cuda | cpu | mp
     # `use_amp` determines whether to use Automatic Mixed Precision (AMP) for training and evaluation. With AMP,


### PR DESCRIPTION
Add a new cli arg which, if specified, allows you to filter image obs.


```
python lerobot/scripts/train.py --dataset.repo_id='["sriramsk/plate_in_bin_20250821_subsampled", "sriramsk/plate_in_bin_20250821_subsampled"]' --policy.type=diffusion --output_dir=outputs/train/concat_debug_tracked2 --job_name=diffPo_plate_in_bin_0821 --policy.device=cuda --wandb.enable=true --policy.use_separate_rgb_encoder_per_camera=true --policy.use_text_embedding=true --policy.input_image_feature_keys='["observation.images.cam_azure_kinect.color"]'


>
(Pdb) (Pdb) batch["observation.images"].shape
torch.Size([8, 2, 1, 3, 720, 1280])
(Pdb) self.config.image_features
{'observation.images.cam_azure_kinect.color': PolicyFeature(type=<FeatureType.VISUAL: 'VISUAL'>, shape=(3, 720, 1280))}
```

```
python lerobot/scripts/train.py --dataset.repo_id='["sriramsk/plate_in_bin_20250821_subsampled"]' --policy.type=diffusion --output_dir=outputs/train/concat_debug_tracked2 --job_name=diffPo_plate_in_bin_0821 --policy.device=cuda --wandb.enable=true --policy.use_separate_rgb_encoder_per_camera=true --policy.use_text_embedding=true --policy.input_image_feature_keys='["observation.images.cam_azure_kinect.color”, “"observation.images.cam_wrist”]’


>

{'observation.images.cam_azure_kinect.color': PolicyFeature(type=<FeatureType.VISUAL: 'VISUAL'>, shape=(3, 720, 1280)), 'observation.images.cam_wrist': PolicyFeature(type=<FeatureType.VISUAL: 'VISUAL'>, shape=(3, 720, 1280))}

(Pdb) batch["observation.images"].shape
torch.Size([8, 2, 2, 3, 720, 1280])
```